### PR TITLE
Make terminal width facility compatible with windows, linux, macOS

### DIFF
--- a/src/jbms/argparse.cpp
+++ b/src/jbms/argparse.cpp
@@ -1164,15 +1164,6 @@ static vector<string> wordwrap_paragraph(string_view input, size_t width) {
       break;
     }
 
-#if 0
-    // Find last space in second half of line
-    auto line = input.substr(0, width);
-    auto second_half = line.substr(width / 2);
-    size_t space_pos = second_half.rfind(' ');
-    if (space_pos != string_view::npos) {
-      line = line.substr(0, space_pos + width / 2);
-    }
-#else
     // See if there is a space in the first width+1 characters
     auto line = input.substr(0, width+1);
     size_t space_pos = line.rfind(' ');
@@ -1181,7 +1172,6 @@ static vector<string> wordwrap_paragraph(string_view input, size_t width) {
       space_pos = input.find(' ', width+1);
     }
     line = input.substr(0, space_pos);
-#endif
 
     output.push_back(string(line));
     input.remove_prefix(line.size());


### PR DESCRIPTION
* add struct `window_size` to hold the row and column number of the current terminal
* add function `get_terminal_dimensions()` to fill the `window_size` object with terminal
	dimensions
* make function `get_terminal_dimesions()` compatible with `windows`, `macOS`, `linux` and `BSD`
	systems
* include the above facility inside `util` namespace

Also,

remove dead code

* remove mistakenly left dead code
* fix issue: #5

@jbms any questions?